### PR TITLE
Add the license file to the dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include whois/data/public_suffix_list.dat
-include README.rst
+include LICENSE.txt README.rst


### PR DESCRIPTION
This is a good practice, and distributions like Fedora tend to require it in
their packaging guidelines.