### PR TITLE
Improved date parsing for .br WhoisBr domain. Changed names for consi…

### DIFF
--- a/whois/parser.py
+++ b/whois/parser.py
@@ -900,7 +900,7 @@ class WhoisBr(WhoisEntry):
     """Whois parser for .br domains
     """
     regex = {
-        'domain':                        'domain: *(.+)\n',
+        'domain_name':                   'domain: *(.+)\n',
         'registrant':                    'owner: *([\S ]+)',
         'registrant_id':                 'ownerid: *(.+)',
         'country':                       'country: *(.+)',
@@ -908,12 +908,12 @@ class WhoisBr(WhoisEntry):
         'admin_c':                       'admin-c: *(.+)',
         'tech_c':                        'tech-c: *(.+)',
         'billing_c':                     'billing-c: *(.+)',
-        'nserver':                       'nserver: *(.+)',
+        'name_server':                   'nserver: *(.+)',
         'nsstat':                        'nsstat: *(.+)',
         'nslastaa':                      'nslastaa: *(.+)',
         'saci':                          'saci: *(.+)',
-        'created':                       'created: *(.+)',
-        'expires':                       'expires: *(.+)',
+        'creation_date':                 'created: *(.+)',
+        'expiration_date':               'expires: *(.+)',
         'changed':                       'changed: *(.+)',
         'status':                        'status: *(.+)',
         'nic_hdl_br':                    'nic-hdl-br: *(.+)',
@@ -928,6 +928,17 @@ class WhoisBr(WhoisEntry):
         else:
             WhoisEntry.__init__(self, domain, text, self.regex)
 
+    def _preprocess(self, attr, value):
+        value = value.strip()
+        if value and isinstance(value, basestring) and '_date' in attr:
+            # try casting to date format
+            value = re.findall(r"[\w\s:.-\\/]+", value)[0].strip()
+            value = cast_date(
+                value,
+                dayfirst=self.dayfirst,
+                yearfirst=self.yearfirst)
+        return value
+        
 
 class WhoisKr(WhoisEntry):
     """Whois parser for .kr domains


### PR DESCRIPTION
…stency

The whois server is BR include these comments in their dates:
created:     20010119 #502185

So I customized the preprocessor to eliminate any character that isn't in the "KNOWN FORMATS".
That caused another problem because these dates are then "not value.isdigit()".

I that may be an error in the main parser as the following KNOWN FORMAT will never get parsed, but I am not sure so I just fixed it for .BR
"    '%Y%m%d',                   # 20170209

Additionally I changed the names to be consistent with the other servers.
Thanks for writing this module. It is very useful.